### PR TITLE
fix: remove duplicate NotificationService import in task service

### DIFF
--- a/src/task/task.service.ts
+++ b/src/task/task.service.ts
@@ -18,7 +18,6 @@ import { TaskDependency } from './task-dependency.entity';
 import { TaskLabel } from './task-label.entity';
 import { NotificationService } from '../notification/notification.service';
 import { ulid } from 'ulid';
-import { NotificationService } from '../notification/notification.service';
 
 @Injectable()
 export class TaskService {


### PR DESCRIPTION
## Summary
- remove duplicated NotificationService import

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1b195dd3083248e5e4ab72de6ecbf