### PR TITLE
feat: add meeting scheduling module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { DocumentModule } from './document/document.module';
 import { TaskLabelModule } from './task/task-label.module';
 import { SprintModule } from './sprint/sprint.module';
+import { MeetingModule } from './meeting/meeting.module';
 
 console.log('✅ ENV VALUES ------------------');
 console.log('DB_HOST:', process.env.DB_HOST);
@@ -58,6 +59,7 @@ console.log('--------------------------------');
     CustomerModule,
     DocumentModule,
     SprintModule,
+    MeetingModule,
   ],
   controllers: [],
   providers: [],

--- a/src/meeting/dto/create-meeting.dto.ts
+++ b/src/meeting/dto/create-meeting.dto.ts
@@ -1,0 +1,48 @@
+import {
+  ArrayUnique,
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateMeetingDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  agenda: string;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @IsDateString()
+  meetingDate: string;
+
+  @Matches(/^([01]\d|2[0-3]):[0-5]\d$/)
+  meetingTime: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @Type(() => Number)
+  @IsInt({ each: true })
+  participantIds?: number[];
+}
+
+export class CreateMeetingResponseDto {
+  id: number;
+  title: string;
+  scheduledAt: Date;
+}

--- a/src/meeting/meeting.controller.ts
+++ b/src/meeting/meeting.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { RolesGuard } from '../auth/roles.guard';
+import { MeetingService } from './meeting.service';
+import { CreateMeetingDto } from './dto/create-meeting.dto';
+import { Request } from 'express';
+
+@Controller('projects/:projectId/meetings')
+@UseGuards(RolesGuard)
+export class MeetingController {
+  constructor(private readonly meetingService: MeetingService) {}
+
+  @Post()
+  async createMeeting(
+    @Param('projectId') projectId: string,
+    @Body() createMeetingDto: CreateMeetingDto,
+    @Req() req: Request,
+  ) {
+    return this.meetingService.createMeeting(+projectId, createMeetingDto, req.user as any);
+  }
+}

--- a/src/meeting/meeting.entity.ts
+++ b/src/meeting/meeting.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+  CreateDateColumn,
+} from 'typeorm';
+import { Project } from '../project/project.entity';
+import { User } from '../user/user.entity';
+
+@Entity()
+export class Meeting {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  location?: string;
+
+  @Column('text')
+  agenda: string;
+
+  @Column('text', { nullable: true })
+  notes?: string;
+
+  @Column({ type: 'timestamp' })
+  scheduledAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Project, (project) => project.meetings, {
+    onDelete: 'CASCADE',
+  })
+  project: Project;
+
+  @ManyToOne(() => User, (user) => user.createdMeetings, {
+    onDelete: 'SET NULL',
+    nullable: true,
+  })
+  createdBy: User | null;
+
+  @ManyToMany(() => User, (user) => user.participatingMeetings)
+  @JoinTable()
+  participants: User[];
+}

--- a/src/meeting/meeting.module.ts
+++ b/src/meeting/meeting.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Meeting } from './meeting.entity';
+import { MeetingService } from './meeting.service';
+import { MeetingController } from './meeting.controller';
+import { Project } from '../project/project.entity';
+import { User } from '../user/user.entity';
+import { ProjectUser } from '../project/project-user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Meeting, Project, User, ProjectUser])],
+  controllers: [MeetingController],
+  providers: [MeetingService],
+  exports: [MeetingService],
+})
+export class MeetingModule {}

--- a/src/meeting/meeting.service.ts
+++ b/src/meeting/meeting.service.ts
@@ -1,0 +1,113 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Meeting } from './meeting.entity';
+import { Project } from '../project/project.entity';
+import { User } from '../user/user.entity';
+import { ProjectUser } from '../project/project-user.entity';
+import { CreateMeetingDto, CreateMeetingResponseDto } from './dto/create-meeting.dto';
+
+@Injectable()
+export class MeetingService {
+  constructor(
+    @InjectRepository(Meeting)
+    private readonly meetingRepository: Repository<Meeting>,
+    @InjectRepository(Project)
+    private readonly projectRepository: Repository<Project>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(ProjectUser)
+    private readonly projectUserRepository: Repository<ProjectUser>,
+  ) {}
+
+  async createMeeting(
+    projectId: number,
+    dto: CreateMeetingDto,
+    creator: { id: number },
+  ): Promise<CreateMeetingResponseDto> {
+    const project = await this.projectRepository.findOne({
+      where: { id: projectId },
+    });
+
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    const creatorUser = await this.userRepository.findOne({
+      where: { id: creator.id },
+    });
+
+    if (!creatorUser) {
+      throw new NotFoundException('User not found');
+    }
+
+    const creatorMembership = await this.projectUserRepository.findOne({
+      where: {
+        project: { id: projectId },
+        user: { id: creatorUser.id },
+      },
+    });
+
+    if (!creatorMembership) {
+      throw new ForbiddenException('You are not a member of this project');
+    }
+
+    const scheduledAt = this.combineDateAndTime(dto.meetingDate, dto.meetingTime);
+
+    const participantIds = dto.participantIds ?? [];
+    let participants: User[] = [];
+
+    if (participantIds.length > 0) {
+      participants = await this.userRepository.find({
+        where: { id: In(participantIds) },
+      });
+
+      if (participants.length !== participantIds.length) {
+        throw new NotFoundException('One or more participants were not found');
+      }
+
+      const memberships = await this.projectUserRepository.find({
+        where: participantIds.map((userId) => ({
+          project: { id: projectId },
+          user: { id: userId },
+        })),
+      });
+
+      if (memberships.length !== participantIds.length) {
+        throw new ForbiddenException('All participants must belong to the project');
+      }
+    }
+
+    const meeting = this.meetingRepository.create({
+      title: dto.title,
+      location: dto.location,
+      agenda: dto.agenda,
+      notes: dto.notes,
+      scheduledAt,
+      project,
+      createdBy: creatorUser,
+      participants,
+    });
+
+    const savedMeeting = await this.meetingRepository.save(meeting);
+
+    return {
+      id: savedMeeting.id,
+      title: savedMeeting.title,
+      scheduledAt: savedMeeting.scheduledAt,
+    };
+  }
+
+  private combineDateAndTime(date: string, time: string): Date {
+    const combined = new Date(`${date}T${time}`);
+    if (Number.isNaN(combined.getTime())) {
+      throw new BadRequestException('Invalid meeting date or time');
+    }
+    return combined;
+  }
+}

--- a/src/project/project.entity.ts
+++ b/src/project/project.entity.ts
@@ -4,15 +4,12 @@ import {
   Column,
   OneToMany,
   CreateDateColumn,
-  ManyToMany,
-  JoinTable,
-  ManyToOne,
 } from 'typeorm';
-import { User } from '../user/user.entity';
 import { Task } from '../task/task.entity';
 import { Customer } from '../customer/customer.entity';
 import { ProjectUser } from './project-user.entity';
-import { Sprint } from '../sprint/sprint.entity'
+import { Sprint } from '../sprint/sprint.entity';
+import { Meeting } from '../meeting/meeting.entity';
 
 @Entity()
 export class Project {
@@ -41,5 +38,8 @@ export class Project {
   userLinks: ProjectUser[];
 
   @OneToMany(() => Sprint, (sprint) => sprint.project)
-  sprints: Sprint[]
+  sprints: Sprint[];
+
+  @OneToMany(() => Meeting, (meeting) => meeting.project)
+  meetings: Meeting[];
 }

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -1,6 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany } from 'typeorm';
-import { Project } from '../project/project.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  ManyToMany,
+} from 'typeorm';
 import { ProjectUser } from '../project/project-user.entity';
+import { Meeting } from '../meeting/meeting.entity';
 
 export enum UserRole {
   DEVELOPER = 'developer',
@@ -34,4 +40,10 @@ export class User {
 
   @OneToMany(() => ProjectUser, (pu) => pu.user)
   projectLinks: ProjectUser[];
+
+  @OneToMany(() => Meeting, (meeting) => meeting.createdBy)
+  createdMeetings: Meeting[];
+
+  @ManyToMany(() => Meeting, (meeting) => meeting.participants)
+  participatingMeetings: Meeting[];
 }

--- a/test/meeting/create-meeting.e2e-spec.ts
+++ b/test/meeting/create-meeting.e2e-spec.ts
@@ -1,0 +1,128 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import * as jwt from 'jsonwebtoken';
+import { AppModule } from '../../src/app.module';
+import { User, UserRole } from '../../src/user/user.entity';
+import { Project } from '../../src/project/project.entity';
+import { ProjectUser, ProjectRole } from '../../src/project/project-user.entity';
+import { Meeting } from '../../src/meeting/meeting.entity';
+
+describe('Meeting creation (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let project: Project;
+  let creator: User;
+  let member: User;
+  let token: string;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    dataSource = app.get(DataSource);
+
+    const userRepo = dataSource.getRepository(User);
+    const projectRepo = dataSource.getRepository(Project);
+    const projectUserRepo = dataSource.getRepository(ProjectUser);
+    const meetingRepo = dataSource.getRepository(Meeting);
+
+    await projectUserRepo.delete({});
+    await meetingRepo.delete({});
+    await projectRepo.delete({});
+    await userRepo.delete({});
+
+    creator = await userRepo.save({
+      firstName: 'Creator',
+      lastName: 'User',
+      email: `creator_${Date.now()}@example.com`,
+      password: 'password',
+      role: UserRole.DEVELOPER,
+    });
+
+    member = await userRepo.save({
+      firstName: 'Member',
+      lastName: 'User',
+      email: `member_${Date.now()}@example.com`,
+      password: 'password',
+      role: UserRole.DEVELOPER,
+    });
+
+    project = await projectRepo.save({
+      name: 'Project Alpha',
+      description: 'Test project',
+      startDate: new Date(),
+    });
+
+    await projectUserRepo.save([
+      { project, user: creator, role: ProjectRole.MANAGER },
+      { project, user: member, role: ProjectRole.DEVELOPER },
+    ]);
+
+    token = jwt.sign({ id: creator.id, role: creator.role }, process.env.JWT_SECRET as string);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('creates a meeting with valid participants', async () => {
+    const response = await request(app.getHttpServer())
+      .post(`/projects/${project.id}/meetings`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Sprint Planning',
+        location: 'Room 101',
+        agenda: 'Discuss next sprint',
+        notes: 'Bring reports',
+        meetingDate: '2025-01-15',
+        meetingTime: '10:30',
+        participantIds: [member.id],
+      })
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      title: 'Sprint Planning',
+    });
+
+    const meetingRepo = dataSource.getRepository(Meeting);
+    const storedMeeting = await meetingRepo.findOne({
+      where: { id: response.body.id },
+      relations: ['project', 'participants', 'createdBy'],
+    });
+
+    expect(storedMeeting).toBeTruthy();
+    expect(storedMeeting?.participants.map((user) => user.id)).toEqual([member.id]);
+    expect(storedMeeting?.project.id).toBe(project.id);
+    expect(storedMeeting?.createdBy?.id).toBe(creator.id);
+  });
+
+  it('rejects participants not in the project', async () => {
+    const outsider = await dataSource.getRepository(User).save({
+      firstName: 'Out',
+      lastName: 'Sider',
+      email: `outsider_${Date.now()}@example.com`,
+      password: 'password',
+      role: UserRole.DEVELOPER,
+    });
+
+    await request(app.getHttpServer())
+      .post(`/projects/${project.id}/meetings`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Invalid Meeting',
+        agenda: 'Should fail',
+        meetingDate: '2025-01-16',
+        meetingTime: '09:00',
+        participantIds: [outsider.id],
+      })
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold a meeting entity, DTOs, service, controller, and module for project meetings
- link meetings to projects and users for ownership and participation tracking
- cover meeting creation and participant validation with e2e tests

## Testing
- npm run test:e2e *(fails: Postgres database not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfc6fd23883248bfbd589cbdbca8f