### PR TITLE
Add backend support for project timeline view

### DIFF
--- a/src/document/document.module.ts
+++ b/src/document/document.module.ts
@@ -8,5 +8,6 @@ import { ProjectDocument, ProjectDocumentSchema } from './document.schema';
   imports: [MongooseModule.forFeature([{ name: ProjectDocument.name, schema: ProjectDocumentSchema }])],
   controllers: [DocumentController],
   providers: [DocumentService],
+  exports: [DocumentService],
 })
 export class DocumentModule {}

--- a/src/project/dto/project-timeline.dto.ts
+++ b/src/project/dto/project-timeline.dto.ts
@@ -1,0 +1,54 @@
+import { Expose, Type } from 'class-transformer';
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+
+export enum ProjectTimelineEventType {
+  TASK = 'task',
+  COMMENT = 'comment',
+  MEETING = 'meeting',
+  DOCUMENT = 'document',
+  SPRINT = 'sprint',
+}
+
+export class ProjectTimelineEventDto {
+  @Expose()
+  type: ProjectTimelineEventType;
+
+  @Expose()
+  id: string;
+
+  @Expose()
+  title: string;
+
+  @Expose()
+  description?: string;
+
+  @Expose()
+  @Type(() => Date)
+  timestamp: Date;
+
+  @Expose()
+  metadata?: Record<string, any>;
+}
+
+export class ProjectTimelineResponseDto {
+  @Expose()
+  projectId: number;
+
+  @Expose()
+  @Type(() => ProjectTimelineEventDto)
+  events: ProjectTimelineEventDto[];
+}
+
+export class ProjectTimelineQueryDto {
+  @IsOptional()
+  @IsString()
+  types?: string;
+
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+}

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param, ParseIntPipe,
   Post,
+  Query,
   Req,
   UseGuards,
   UseInterceptors,
@@ -16,6 +17,7 @@ import { Roles } from '../auth/roles.decorator';
 import { ProjectResponseDto, ProjectUsersResponseDto } from './dto/project-response.dto';
 import { MessageDto } from '../common/dto/message.dto';
 import { AssignUserDto } from './dto/assign-user.dto';
+import { ProjectTimelineQueryDto, ProjectTimelineResponseDto } from './dto/project-timeline.dto';
 
 
 @Controller('projects')
@@ -54,6 +56,15 @@ export class ProjectController {
   ): Promise<{ message: string }> {
     await this.projectService.assignUserToProject(projectId, dto);
     return { message: 'Kullanıcı projeye atandı' };
+  }
+
+  @Get(':projectId/timeline')
+  @Roles('admin', 'director', 'developer', 'tester', 'devOps')
+  async getProjectTimeline(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Query() query: ProjectTimelineQueryDto,
+  ): Promise<ProjectTimelineResponseDto> {
+    return this.projectService.getProjectTimeline(projectId, query);
   }
 
   @Delete(':projectId/users/:userId')

--- a/src/project/project.module.ts
+++ b/src/project/project.module.ts
@@ -5,9 +5,17 @@ import { ProjectService } from './project.service';
 import { ProjectController } from './project.controller';
 import { User } from '../user/user.entity';
 import { ProjectUser } from './project-user.entity';
+import { Task } from '../task/task.entity';
+import { Comment } from '../comment/comment.entity';
+import { Meeting } from '../meeting/meeting.entity';
+import { Sprint } from '../sprint/sprint.entity';
+import { DocumentModule } from '../document/document.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project, User, ProjectUser])],
+  imports: [
+    TypeOrmModule.forFeature([Project, User, ProjectUser, Task, Comment, Meeting, Sprint]),
+    DocumentModule,
+  ],
   providers: [ProjectService],
   controllers: [ProjectController],
   exports: [ProjectService]

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -8,6 +8,17 @@ import { plainToInstance } from 'class-transformer';
 import { ProjectResponseDto, ProjectUsersResponseDto } from './dto/project-response.dto';
 import { AssignUserDto } from './dto/assign-user.dto';
 import { ProjectRole, ProjectUser } from './project-user.entity';
+import { Task } from '../task/task.entity';
+import { Comment } from '../comment/comment.entity';
+import { Meeting } from '../meeting/meeting.entity';
+import { Sprint } from '../sprint/sprint.entity';
+import { DocumentService } from '../document/document.service';
+import {
+  ProjectTimelineEventDto,
+  ProjectTimelineEventType,
+  ProjectTimelineQueryDto,
+  ProjectTimelineResponseDto,
+} from './dto/project-timeline.dto';
 
 @Injectable()
 export class ProjectService {
@@ -17,7 +28,16 @@ export class ProjectService {
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     @InjectRepository(ProjectUser)
-    private readonly projectUserRepo: Repository<ProjectUser>
+    private readonly projectUserRepo: Repository<ProjectUser>,
+    @InjectRepository(Task)
+    private readonly taskRepo: Repository<Task>,
+    @InjectRepository(Comment)
+    private readonly commentRepo: Repository<Comment>,
+    @InjectRepository(Meeting)
+    private readonly meetingRepo: Repository<Meeting>,
+    @InjectRepository(Sprint)
+    private readonly sprintRepo: Repository<Sprint>,
+    private readonly documentService: DocumentService,
   ) {}
 
   async createProject(createDto: CreateProjectDto, userId: number): Promise<void> {
@@ -105,5 +125,214 @@ export class ProjectService {
       project: { id: projectId },
       user: { id: userId }
     })
+  }
+
+  async getProjectTimeline(
+    projectId: number,
+    filters: ProjectTimelineQueryDto,
+  ): Promise<ProjectTimelineResponseDto> {
+    const project = await this.projectRepo.findOne({ where: { id: projectId } });
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    const allowedTypes = new Set(Object.values(ProjectTimelineEventType));
+    const requestedTypes = filters?.types
+      ? filters.types
+          .split(',')
+          .map((type) => type.trim())
+          .filter((type) => allowedTypes.has(type as ProjectTimelineEventType))
+          .map((type) => type as ProjectTimelineEventType)
+      : null;
+    const requestedTypeSet = requestedTypes && requestedTypes.length > 0 ? new Set(requestedTypes) : null;
+    const shouldInclude = (type: ProjectTimelineEventType) => !requestedTypeSet || requestedTypeSet.has(type);
+
+    const fromDate = filters?.from ? new Date(filters.from) : null;
+    const toDate = filters?.to ? new Date(filters.to) : null;
+
+    const tasksPromise = shouldInclude(ProjectTimelineEventType.TASK)
+      ? this.taskRepo.find({ where: { project: { id: projectId } } })
+      : Promise.resolve([]);
+
+    const commentsPromise = shouldInclude(ProjectTimelineEventType.COMMENT)
+      ? this.commentRepo
+          .createQueryBuilder('comment')
+          .leftJoinAndSelect('comment.author', 'author')
+          .leftJoinAndSelect('comment.task', 'task')
+          .leftJoin('task.project', 'project')
+          .where('project.id = :projectId', { projectId })
+          .getMany()
+      : Promise.resolve([]);
+
+    const meetingsPromise = shouldInclude(ProjectTimelineEventType.MEETING)
+      ? this.meetingRepo.find({
+          where: { project: { id: projectId } },
+          relations: ['createdBy', 'participants'],
+        })
+      : Promise.resolve([]);
+
+    const sprintsPromise = shouldInclude(ProjectTimelineEventType.SPRINT)
+      ? this.sprintRepo.find({
+          where: { project: { id: projectId } },
+          relations: ['createdBy'],
+        })
+      : Promise.resolve([]);
+
+    const documentsPromise = shouldInclude(ProjectTimelineEventType.DOCUMENT)
+      ? this.documentService.findByProject(projectId.toString())
+      : Promise.resolve([]);
+
+    const [tasks, comments, meetings, sprints, documents] = await Promise.all([
+      tasksPromise,
+      commentsPromise,
+      meetingsPromise,
+      sprintsPromise,
+      documentsPromise,
+    ]);
+
+    const events: ProjectTimelineEventDto[] = [];
+
+    for (const task of tasks) {
+      if (!task.createdAt) {
+        continue;
+      }
+
+      events.push({
+        type: ProjectTimelineEventType.TASK,
+        id: `task-${task.id}`,
+        title: task.title,
+        description: task.description,
+        timestamp: new Date(task.createdAt),
+        metadata: {
+          status: task.status,
+          level: task.level,
+          deadline: task.deadline ?? null,
+          sprintId: task.sprintId ?? null,
+          assignee: task.assignedTo
+            ? {
+                id: task.assignedTo.id,
+                name: `${task.assignedTo.firstName} ${task.assignedTo.lastName}`.trim(),
+              }
+            : null,
+        },
+      });
+    }
+
+    for (const comment of comments) {
+      if (!comment.createdAt || !comment.task) {
+        continue;
+      }
+
+      events.push({
+        type: ProjectTimelineEventType.COMMENT,
+        id: `comment-${comment.id}`,
+        title: comment.task.title,
+        description: comment.content,
+        timestamp: new Date(comment.createdAt),
+        metadata: {
+          taskId: comment.task.id,
+          author: comment.author
+            ? {
+                id: comment.author.id,
+                name: `${comment.author.firstName} ${comment.author.lastName}`.trim(),
+              }
+            : null,
+        },
+      });
+    }
+
+    for (const meeting of meetings) {
+      const timestamp = meeting.scheduledAt ?? meeting.createdAt;
+      if (!timestamp) {
+        continue;
+      }
+
+      events.push({
+        type: ProjectTimelineEventType.MEETING,
+        id: `meeting-${meeting.id}`,
+        title: meeting.title,
+        description: meeting.notes ?? meeting.agenda,
+        timestamp: new Date(timestamp),
+        metadata: {
+          location: meeting.location ?? null,
+          createdBy: meeting.createdBy
+            ? {
+                id: meeting.createdBy.id,
+                name: `${meeting.createdBy.firstName} ${meeting.createdBy.lastName}`.trim(),
+              }
+            : null,
+          participantCount: meeting.participants?.length ?? 0,
+        },
+      });
+    }
+
+    for (const sprint of sprints) {
+      if (!sprint.createdAt) {
+        continue;
+      }
+
+      events.push({
+        type: ProjectTimelineEventType.SPRINT,
+        id: `sprint-${sprint.id}`,
+        title: sprint.name,
+        description: sprint.goal ?? undefined,
+        timestamp: new Date(sprint.createdAt),
+        metadata: {
+          startDate: sprint.startDate,
+          endDate: sprint.endDate,
+          createdBy: sprint.createdBy
+            ? {
+                id: sprint.createdBy.id,
+                name: `${sprint.createdBy.firstName} ${sprint.createdBy.lastName}`.trim(),
+              }
+            : null,
+        },
+      });
+    }
+
+    for (const document of documents as any[]) {
+      const createdAt = document?.createdAt ? new Date(document.createdAt) : null;
+      if (!createdAt || Number.isNaN(createdAt.getTime())) {
+        continue;
+      }
+
+      const updatedAt = document?.updatedAt ? new Date(document.updatedAt) : null;
+
+      events.push({
+        type: ProjectTimelineEventType.DOCUMENT,
+        id: `document-${document._id?.toString?.() ?? document.id ?? document._id}`,
+        title: document.title,
+        description: document.desc ?? undefined,
+        timestamp: createdAt,
+        metadata: {
+          parentId: document.parentId ?? null,
+          updatedAt: updatedAt && !Number.isNaN(updatedAt.getTime()) ? updatedAt : null,
+        },
+      });
+    }
+
+    const filteredEvents = events.filter((event) => {
+      if (!event.timestamp || Number.isNaN(event.timestamp.getTime())) {
+        return false;
+      }
+      if (fromDate && !Number.isNaN(fromDate.getTime()) && event.timestamp < fromDate) {
+        return false;
+      }
+      if (toDate && !Number.isNaN(toDate.getTime()) && event.timestamp > toDate) {
+        return false;
+      }
+      return true;
+    });
+
+    filteredEvents.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+
+    return plainToInstance(
+      ProjectTimelineResponseDto,
+      {
+        projectId: project.id,
+        events: filteredEvents,
+      },
+      { excludeExtraneousValues: true },
+    );
   }
 }


### PR DESCRIPTION
## Summary
- export the document service so project aggregation can pull project documents
- add timeline DTOs and service logic that aggregates tasks, comments, meetings, sprints, and documents for a project
- expose a protected GET /projects/:projectId/timeline endpoint returning the sorted timeline data

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68dc10af00788324bd220b6ee18a02ea