### PR TITLE
Add mediasoup voice room backend support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "nodemailer": "^7.0.5",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "mediasoup": "^3.14.10",
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { DocumentModule } from './document/document.module';
 import { TaskLabelModule } from './task/task-label.module';
 import { SprintModule } from './sprint/sprint.module';
 import { MeetingModule } from './meeting/meeting.module';
+import { VoiceRoomModule } from './voice-room/voice-room.module';
 
 console.log('✅ ENV VALUES ------------------');
 console.log('DB_HOST:', process.env.DB_HOST);
@@ -60,6 +61,7 @@ console.log('--------------------------------');
     DocumentModule,
     SprintModule,
     MeetingModule,
+    VoiceRoomModule,
   ],
   controllers: [],
   providers: [],

--- a/src/voice-room/dto/connect-transport.dto.ts
+++ b/src/voice-room/dto/connect-transport.dto.ts
@@ -1,0 +1,13 @@
+import { IsObject, IsString } from 'class-validator';
+import { DtlsParameters } from 'mediasoup/node/lib/types';
+
+export class ConnectTransportDto {
+  @IsString()
+  peerId!: string;
+
+  @IsString()
+  transportId!: string;
+
+  @IsObject()
+  dtlsParameters!: DtlsParameters;
+}

--- a/src/voice-room/dto/consume.dto.ts
+++ b/src/voice-room/dto/consume.dto.ts
@@ -1,0 +1,13 @@
+import { IsObject, IsString } from 'class-validator';
+import { RtpCapabilities } from 'mediasoup/node/lib/types';
+
+export class ConsumeDto {
+  @IsString()
+  peerId!: string;
+
+  @IsString()
+  producerId!: string;
+
+  @IsObject()
+  rtpCapabilities!: RtpCapabilities;
+}

--- a/src/voice-room/dto/create-transport.dto.ts
+++ b/src/voice-room/dto/create-transport.dto.ts
@@ -1,0 +1,15 @@
+import { IsEnum, IsString } from 'class-validator';
+import { TransportDirection } from '../voice-room.service';
+
+enum Direction {
+  SEND = 'send',
+  RECV = 'recv',
+}
+
+export class CreateTransportDto {
+  @IsEnum(Direction)
+  direction!: TransportDirection;
+
+  @IsString()
+  peerId!: string;
+}

--- a/src/voice-room/dto/produce.dto.ts
+++ b/src/voice-room/dto/produce.dto.ts
@@ -1,0 +1,16 @@
+import { IsObject, IsString } from 'class-validator';
+import { MediaKind, RtpParameters } from 'mediasoup/node/lib/types';
+
+export class ProduceDto {
+  @IsString()
+  peerId!: string;
+
+  @IsString()
+  transportId!: string;
+
+  @IsString()
+  kind!: MediaKind;
+
+  @IsObject()
+  rtpParameters!: RtpParameters;
+}

--- a/src/voice-room/voice-room.controller.ts
+++ b/src/voice-room/voice-room.controller.ts
@@ -1,0 +1,88 @@
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { VoiceRoomService } from './voice-room.service';
+import { CreateTransportDto } from './dto/create-transport.dto';
+import { ConnectTransportDto } from './dto/connect-transport.dto';
+import { ProduceDto } from './dto/produce.dto';
+import { ConsumeDto } from './dto/consume.dto';
+
+@Controller('voice-room')
+export class VoiceRoomController {
+  constructor(private readonly voiceRoomService: VoiceRoomService) {}
+
+  @Get('rooms/:roomId/rtp-capabilities')
+  async getRouterRtpCapabilities(@Param('roomId') roomId: string) {
+    return this.voiceRoomService.getRouterRtpCapabilities(roomId);
+  }
+
+  @Post('rooms/:roomId/transports')
+  async createTransport(
+    @Param('roomId') roomId: string,
+    @Body() dto: CreateTransportDto,
+  ) {
+    const transport = await this.voiceRoomService.createWebRtcTransport(
+      roomId,
+      dto.peerId,
+      dto.direction,
+    );
+    return transport;
+  }
+
+  @Post('rooms/:roomId/transports/connect')
+  async connectTransport(
+    @Param('roomId') roomId: string,
+    @Body() dto: ConnectTransportDto,
+  ) {
+    await this.voiceRoomService.connectWebRtcTransport(
+      roomId,
+      dto.peerId,
+      dto.transportId,
+      dto.dtlsParameters,
+    );
+    return { status: 'connected' };
+  }
+
+  @Post('rooms/:roomId/producers')
+  async produce(@Param('roomId') roomId: string, @Body() dto: ProduceDto) {
+    const producer = await this.voiceRoomService.produce(
+      roomId,
+      dto.peerId,
+      dto.transportId,
+      dto.kind,
+      dto.rtpParameters,
+    );
+
+    return {
+      id: producer.id,
+      kind: producer.kind,
+    };
+  }
+
+  @Post('rooms/:roomId/consumers')
+  async consume(@Param('roomId') roomId: string, @Body() dto: ConsumeDto) {
+    const consumer = await this.voiceRoomService.consume(
+      roomId,
+      dto.peerId,
+      dto.producerId,
+      dto.rtpCapabilities,
+    );
+
+    return {
+      id: consumer.id,
+      producerId: consumer.producerId,
+      kind: consumer.kind,
+      rtpParameters: consumer.rtpParameters,
+      type: consumer.type,
+      appData: consumer.appData,
+      producerPaused: consumer.producerPaused,
+    };
+  }
+
+  @Delete('rooms/:roomId/peers/:peerId')
+  async closePeer(
+    @Param('roomId') roomId: string,
+    @Param('peerId') peerId: string,
+  ) {
+    await this.voiceRoomService.closePeer(roomId, peerId);
+    return { status: 'left' };
+  }
+}

--- a/src/voice-room/voice-room.module.ts
+++ b/src/voice-room/voice-room.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { VoiceRoomService } from './voice-room.service';
+import { VoiceRoomController } from './voice-room.controller';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [VoiceRoomController],
+  providers: [VoiceRoomService],
+  exports: [VoiceRoomService],
+})
+export class VoiceRoomModule {}

--- a/src/voice-room/voice-room.service.ts
+++ b/src/voice-room/voice-room.service.ts
@@ -1,0 +1,402 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  RtpCapabilities,
+  RtpCodecCapability,
+  WebRtcTransport,
+  Worker,
+  Router,
+  Producer,
+  Consumer,
+  DtlsParameters,
+  RtpParameters,
+  DataProducer,
+  DataConsumer,
+  IceParameters,
+  IceCandidate,
+  SctpParameters,
+} from 'mediasoup/node/lib/types';
+import { createWorker, types as mediasoupTypes } from 'mediasoup';
+
+interface VoiceRoom {
+  id: string;
+  router: Router;
+  audioLevelObserver: mediasoupTypes.AudioLevelObserver;
+  peers: Map<string, VoiceRoomPeer>;
+}
+
+interface VoiceRoomPeer {
+  transports: Map<string, WebRtcTransport>;
+  producers: Map<string, Producer>;
+  consumers: Map<string, Consumer>;
+  dataProducers: Map<string, DataProducer>;
+  dataConsumers: Map<string, DataConsumer>;
+}
+
+export type TransportDirection = 'send' | 'recv';
+
+export interface TransportInfo {
+  id: string;
+  iceParameters: IceParameters;
+  iceCandidates: IceCandidate[];
+  dtlsParameters: DtlsParameters;
+  sctpParameters?: SctpParameters;
+}
+
+@Injectable()
+export class VoiceRoomService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(VoiceRoomService.name);
+  private worker: Worker | null = null;
+  private readonly rooms = new Map<string, VoiceRoom>();
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.ensureWorker();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    for (const room of this.rooms.values()) {
+      room.audioLevelObserver.close();
+      room.router.close();
+    }
+    this.rooms.clear();
+
+    if (this.worker) {
+      this.worker.close();
+      this.worker = null;
+    }
+  }
+
+  async getRouterRtpCapabilities(roomId: string): Promise<RtpCapabilities> {
+    const room = await this.getOrCreateRoom(roomId);
+    return room.router.rtpCapabilities;
+  }
+
+  async createWebRtcTransport(
+    roomId: string,
+    peerId: string,
+    direction: TransportDirection,
+  ): Promise<TransportInfo> {
+    const room = await this.getOrCreateRoom(roomId);
+    const peer = this.getOrCreatePeer(room, peerId);
+
+    const transport = await room.router.createWebRtcTransport({
+      listenIps: [
+        {
+          ip: this.configService.get<string>('MEDIASOUP_LISTEN_IP', '0.0.0.0'),
+          announcedIp:
+            this.configService.get<string>('MEDIASOUP_ANNOUNCED_IP') ??
+            undefined,
+        },
+      ],
+      enableUdp: true,
+      enableTcp: true,
+      preferUdp: true,
+      initialAvailableOutgoingBitrate: Number(
+        this.configService.get<number>('MEDIASOUP_INITIAL_BITRATE', 600_000),
+      ),
+      appData: {
+        peerId,
+        roomId,
+        direction,
+      },
+    });
+
+    peer.transports.set(transport.id, transport);
+
+    transport.on('dtlsstatechange', (state) => {
+      if (state === 'closed' || state === 'failed') {
+        this.logger.warn(
+          `DTLS state changed to ${state} for transport ${transport.id}`,
+        );
+        transport.close();
+        peer.transports.delete(transport.id);
+      }
+    });
+
+    transport.on('close', () => {
+      peer.transports.delete(transport.id);
+    });
+
+    return {
+      id: transport.id,
+      iceParameters: transport.iceParameters,
+      iceCandidates: transport.iceCandidates,
+      dtlsParameters: transport.dtlsParameters,
+      sctpParameters: transport.sctpParameters,
+    };
+  }
+
+  async connectWebRtcTransport(
+    roomId: string,
+    peerId: string,
+    transportId: string,
+    dtlsParameters: DtlsParameters,
+  ): Promise<void> {
+    const transport = this.getTransport(roomId, peerId, transportId);
+    await transport.connect({ dtlsParameters });
+  }
+
+  async produce(
+    roomId: string,
+    peerId: string,
+    transportId: string,
+    kind: mediasoupTypes.MediaKind,
+    rtpParameters: RtpParameters,
+  ): Promise<Producer> {
+    const transport = this.getTransport(roomId, peerId, transportId);
+
+    if (transport.appData.direction !== 'send') {
+      throw new BadRequestException('Transport is not configured for sending');
+    }
+
+    const producer = await transport.produce({ kind, rtpParameters });
+
+    const peer = this.getPeer(roomId, peerId);
+    peer.producers.set(producer.id, producer);
+
+    producer.on('transportclose', () => {
+      producer.close();
+      peer.producers.delete(producer.id);
+    });
+
+    producer.on('close', () => {
+      peer.producers.delete(producer.id);
+    });
+
+    return producer;
+  }
+
+  async consume(
+    roomId: string,
+    peerId: string,
+    producerId: string,
+    rtpCapabilities: RtpCapabilities,
+  ): Promise<Consumer> {
+    const room = await this.getOrCreateRoom(roomId);
+    const peer = this.getPeer(roomId, peerId);
+    const producer = this.getProducer(roomId, producerId);
+
+    if (!room.router.canConsume({ producerId: producer.id, rtpCapabilities })) {
+      throw new BadRequestException(
+        'Client cannot consume the specified producer',
+      );
+    }
+
+    const recvTransport = Array.from(peer.transports.values()).find(
+      (transport) => transport.appData.direction === 'recv',
+    );
+
+    if (!recvTransport) {
+      throw new BadRequestException(
+        'No receiving transport available for peer',
+      );
+    }
+
+    const consumer = await recvTransport.consume({
+      producerId: producer.id,
+      rtpCapabilities,
+      paused: producer.kind === 'video',
+    });
+
+    peer.consumers.set(consumer.id, consumer);
+
+    consumer.on('transportclose', () => {
+      consumer.close();
+      peer.consumers.delete(consumer.id);
+    });
+
+    consumer.on('producerclose', () => {
+      consumer.close();
+      peer.consumers.delete(consumer.id);
+    });
+
+    return consumer;
+  }
+
+  async closePeer(roomId: string, peerId: string): Promise<void> {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      return;
+    }
+
+    const peer = room.peers.get(peerId);
+    if (!peer) {
+      return;
+    }
+
+    for (const consumer of peer.consumers.values()) {
+      consumer.close();
+    }
+    for (const producer of peer.producers.values()) {
+      producer.close();
+    }
+    for (const transport of peer.transports.values()) {
+      transport.close();
+    }
+    for (const dataConsumer of peer.dataConsumers.values()) {
+      dataConsumer.close();
+    }
+    for (const dataProducer of peer.dataProducers.values()) {
+      dataProducer.close();
+    }
+
+    room.peers.delete(peerId);
+
+    if (room.peers.size === 0) {
+      this.logger.log(`Closing empty room ${roomId}`);
+      room.audioLevelObserver.close();
+      room.router.close();
+      this.rooms.delete(roomId);
+    }
+  }
+
+  private async ensureWorker(): Promise<void> {
+    if (this.worker) {
+      return;
+    }
+
+    const logLevel = this.configService.get<mediasoupTypes.LogLevel>(
+      'MEDIASOUP_LOG_LEVEL',
+      'warn',
+    );
+    const logTags = (
+      this.configService.get<string>('MEDIASOUP_LOG_TAGS', '') || ''
+    )
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => Boolean(tag)) as mediasoupTypes.LogTag[];
+
+    this.worker = await createWorker({
+      rtcMinPort: Number(
+        this.configService.get<number>('MEDIASOUP_RTC_MIN_PORT', 40000),
+      ),
+      rtcMaxPort: Number(
+        this.configService.get<number>('MEDIASOUP_RTC_MAX_PORT', 49999),
+      ),
+      logLevel,
+      logTags,
+    });
+
+    this.worker.on('died', async () => {
+      this.logger.error('Mediasoup worker died, recreating worker');
+      this.worker = null;
+      setTimeout(
+        () => this.ensureWorker().catch((error) => this.logger.error(error)),
+        1000,
+      );
+    });
+  }
+
+  private async getOrCreateRoom(roomId: string): Promise<VoiceRoom> {
+    await this.ensureWorker();
+    if (!this.worker) {
+      throw new Error('Mediasoup worker is not available');
+    }
+
+    let room = this.rooms.get(roomId);
+    if (room) {
+      return room;
+    }
+
+    const router = await this.worker.createRouter({
+      mediaCodecs: this.getMediaCodecs(),
+    });
+
+    const audioLevelObserver = await router.createAudioLevelObserver({
+      maxEntries: 1,
+      threshold: -80,
+      interval: 800,
+    });
+
+    room = {
+      id: roomId,
+      router,
+      audioLevelObserver,
+      peers: new Map(),
+    };
+
+    this.rooms.set(roomId, room);
+    return room;
+  }
+
+  private getOrCreatePeer(room: VoiceRoom, peerId: string): VoiceRoomPeer {
+    let peer = room.peers.get(peerId);
+    if (!peer) {
+      peer = {
+        transports: new Map(),
+        producers: new Map(),
+        consumers: new Map(),
+        dataProducers: new Map(),
+        dataConsumers: new Map(),
+      };
+      room.peers.set(peerId, peer);
+    }
+    return peer;
+  }
+
+  private getPeer(roomId: string, peerId: string): VoiceRoomPeer {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      throw new NotFoundException('Room not found');
+    }
+
+    const peer = room.peers.get(peerId);
+    if (!peer) {
+      throw new NotFoundException('Peer not found in room');
+    }
+
+    return peer;
+  }
+
+  private getTransport(
+    roomId: string,
+    peerId: string,
+    transportId: string,
+  ): WebRtcTransport {
+    const peer = this.getPeer(roomId, peerId);
+    const transport = peer.transports.get(transportId);
+    if (!transport) {
+      throw new NotFoundException('Transport not found');
+    }
+    return transport;
+  }
+
+  private getProducer(roomId: string, producerId: string): Producer {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      throw new NotFoundException('Room not found');
+    }
+
+    for (const peer of room.peers.values()) {
+      const producer = peer.producers.get(producerId);
+      if (producer) {
+        return producer;
+      }
+    }
+
+    throw new NotFoundException('Producer not found in room');
+  }
+
+  private getMediaCodecs(): RtpCodecCapability[] {
+    const opus: RtpCodecCapability = {
+      kind: 'audio',
+      mimeType: 'audio/opus',
+      clockRate: 48000,
+      channels: 2,
+      parameters: {
+        useinbandfec: 1,
+      },
+    };
+
+    return [opus];
+  }
+}


### PR DESCRIPTION
## Summary
- add mediasoup dependency and register the new voice room module
- implement mediasoup-backed voice room service with REST endpoints for router capabilities, transports, producers, and consumers
- provide DTOs and controller wiring for managing peer lifecycle in voice rooms

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6b144e788324ae383b8d8596445a