### PR TITLE
feat: expose voice room state endpoint

### DIFF
--- a/src/voice-room/dto/voice-room-state.dto.ts
+++ b/src/voice-room/dto/voice-room-state.dto.ts
@@ -1,0 +1,23 @@
+import { MediaKind } from 'mediasoup/node/lib/types';
+
+export interface VoiceRoomProducerStateDto {
+  id: string;
+  kind: MediaKind;
+}
+
+export interface VoiceRoomConsumerStateDto {
+  id: string;
+  producerId: string;
+  kind: MediaKind;
+}
+
+export interface VoiceRoomPeerStateDto {
+  peerId: string;
+  producers: VoiceRoomProducerStateDto[];
+  consumers: VoiceRoomConsumerStateDto[];
+}
+
+export interface VoiceRoomStateDto {
+  roomId: string;
+  peers: VoiceRoomPeerStateDto[];
+}

--- a/src/voice-room/voice-room.controller.ts
+++ b/src/voice-room/voice-room.controller.ts
@@ -9,6 +9,11 @@ import { ConsumeDto } from './dto/consume.dto';
 export class VoiceRoomController {
   constructor(private readonly voiceRoomService: VoiceRoomService) {}
 
+  @Get('rooms/:roomId/state')
+  getRoomState(@Param('roomId') roomId: string) {
+    return this.voiceRoomService.getRoomState(roomId);
+  }
+
   @Get('rooms/:roomId/rtp-capabilities')
   async getRouterRtpCapabilities(@Param('roomId') roomId: string) {
     return this.voiceRoomService.getRouterRtpCapabilities(roomId);

--- a/src/voice-room/voice-room.service.ts
+++ b/src/voice-room/voice-room.service.ts
@@ -24,6 +24,7 @@ import {
   SctpParameters,
 } from 'mediasoup/node/lib/types';
 import { createWorker, types as mediasoupTypes } from 'mediasoup';
+import { VoiceRoomStateDto } from './dto/voice-room-state.dto';
 
 interface VoiceRoom {
   id: string;
@@ -220,6 +221,33 @@ export class VoiceRoomService implements OnModuleInit, OnModuleDestroy {
     });
 
     return consumer;
+  }
+
+  getRoomState(roomId: string): VoiceRoomStateDto {
+    const room = this.rooms.get(roomId);
+
+    if (!room) {
+      return {
+        roomId,
+        peers: [],
+      };
+    }
+
+    return {
+      roomId,
+      peers: Array.from(room.peers.entries()).map(([peerId, peer]) => ({
+        peerId,
+        producers: Array.from(peer.producers.values()).map((producer) => ({
+          id: producer.id,
+          kind: producer.kind,
+        })),
+        consumers: Array.from(peer.consumers.values()).map((consumer) => ({
+          id: consumer.id,
+          producerId: consumer.producerId,
+          kind: consumer.kind,
+        })),
+      })),
+    };
   }
 
   async closePeer(roomId: string, peerId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add DTOs describing voice room state
- expose a controller endpoint to return the current peers, producers, and consumers for a room

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e65c4c079483249ea8c2f364eee67b